### PR TITLE
Added support to update firmware.

### DIFF
--- a/carreralib/__main__.py
+++ b/carreralib/__main__.py
@@ -95,17 +95,17 @@ class RMS(object):
                 elif c == ord('r'):
                     self.reset()
                 elif c == ord(' '):
-                    self.cu.start()
+                    self.cu.presskey(ControlUnit.START_KEY)
                 elif (c == 27):  # ESC
-                    self.cu.request(ControlUnit.PACE_CAR_KEY)
+                    self.cu.presskey(ControlUnit.PACE_CAR_KEY)
                 elif c == ord('s'):
-                    self.cu.request(ControlUnit.SPEED_KEY)
+                    self.cu.presskey(ControlUnit.SPEED_KEY)
                 elif c == ord('b'):
-                    self.cu.request(ControlUnit.BRAKE_KEY)
+                    self.cu.presskey(ControlUnit.BRAKE_KEY)
                 elif c == ord('f'):
-                    self.cu.request(ControlUnit.FUEL_KEY)
+                    self.cu.presskey(ControlUnit.FUEL_KEY)
                 elif c == ord('c'):
-                    self.cu.request(ControlUnit.CODE_KEY)
+                    self.cu.presskey(ControlUnit.CODE_KEY)
                 data = self.cu.request()
                 # prevent counting duplicate laps
                 if data == last:

--- a/carreralib/cu.py
+++ b/carreralib/cu.py
@@ -205,16 +205,15 @@ class ControlUnit(object):
     def updatefw(self, updatefile):
         """Update CU firmware given path to update file."""
         self.request(protocol.pack('ccC', b'G', b'B'))
+        time.sleep(1.0)
 
         logger.info('Firmware update started')
-
-        time.sleep(1.0)
 
         with open(updatefile) as file:
             totallines = sum(1 for _ in file)
 
-        thresh = 0.1
         numlines = 0
+        thresh = 0.1
         with open(updatefile) as file:
             for line in file:
                 # remove the double quotes wrapping each line

--- a/carreralib/cu.py
+++ b/carreralib/cu.py
@@ -116,7 +116,8 @@ class ControlUnit(object):
         depending on whether any timer events are pending.
 
         """
-        #logger.debug('Sending message %r', buf)
+        if not buf.startswith(b'?'):
+            logger.debug('Sending message %r', buf)
         self.__connection.send(buf)
         while True:
             res = self.__connection.recv(maxlength)
@@ -127,7 +128,8 @@ class ControlUnit(object):
                 break
             else:
                 logger.warn('Received unexpected message %r', res)
-        #logger.debug('Received message %r', res)
+        if not res.startswith(b'?'):
+            logger.debug('Received message %r', res)
         if res.startswith(b'?:'):
             # recent CU versions report two extra unknown bytes with '?:'
             try:

--- a/carreralib/fw.py
+++ b/carreralib/fw.py
@@ -1,0 +1,24 @@
+import argparse
+import contextlib
+import logging
+
+from . import ControlUnit
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(prog='python -m carreralib.fw')
+    parser.add_argument('device', metavar='DEVICE')
+    parser.add_argument('updatefile', metavar='FILE')
+    parser.add_argument('-l', '--logfile', nargs="?", default='carreralib.log', const=None)
+    parser.add_argument('-t', '--timeout', default=1.0, type=float)
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        filename=args.logfile,
+                        format='%(asctime)s: %(message)s')
+
+    with contextlib.closing(ControlUnit(args.device, timeout=args.timeout)) as cu:
+        print('CU version %s' % cu.version().decode())
+
+        #cu.updatefw(args.updatefile)

--- a/carreralib/fw.py
+++ b/carreralib/fw.py
@@ -8,8 +8,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(prog='python -m carreralib.fw')
     parser.add_argument('device', metavar='DEVICE')
-    parser.add_argument('updatefile', metavar='FILE')
-    parser.add_argument('-l', '--logfile', nargs="?", default='carreralib.log', const=None)
+    parser.add_argument('updatefile', metavar='FILE', nargs='?', default=None)
+    parser.add_argument('-l', '--logfile', nargs='?', default='carreralib.log', const=None)
     parser.add_argument('-t', '--timeout', default=1.0, type=float)
     parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
@@ -21,4 +21,6 @@ if __name__ == "__main__":
     with contextlib.closing(ControlUnit(args.device, timeout=args.timeout)) as cu:
         print('CU version %s' % cu.version().decode())
 
-        cu.updatefw(args.updatefile)
+        if args.updatefile:
+            cu.updatefw(args.updatefile)
+

--- a/carreralib/fw.py
+++ b/carreralib/fw.py
@@ -21,4 +21,4 @@ if __name__ == "__main__":
     with contextlib.closing(ControlUnit(args.device, timeout=args.timeout)) as cu:
         print('CU version %s' % cu.version().decode())
 
-        #cu.updatefw(args.updatefile)
+        cu.updatefw(args.updatefile)

--- a/carreralib/protocol.py
+++ b/carreralib/protocol.py
@@ -111,7 +111,7 @@ def _pack_s(buf, args, count, base=ord('0')):
     arg = next(args)
     if not isinstance(arg, bytes):
         raise ValueError("'s' format requires a bytes object")
-    buf.extend(arg.ljust(count, base)[:count])
+    buf.extend(arg.ljust(count, base.to_bytes(1, byteorder='little'))[:count])
 
 
 def _pack_x(buf, args, count, base=ord('0')):

--- a/carreralib/serial.py
+++ b/carreralib/serial.py
@@ -19,7 +19,7 @@ class SerialConnection(Connection):
             c = self.__serial.read()
             if not c:
                 raise TimeoutError('Timeout waiting for serial data')
-            elif c == b'$':
+            elif c == b'$' or c == b'#':
                 break
             elif maxlength is not None and maxlength <= len(buf):
                 raise BufferTooShort('Buffer too short for data received')


### PR DESCRIPTION
This PR adds support for updating firmware in the CU by adding the method `ControlUnit.updatefw()`. Additionally, a new module `fw.py` has been added to easily update firmware from the command line like so:
```
python -m carreralib.fw DEVICE UPDATEFILE
```
Also, a couple small fixes have been added to support the new code:
1. Converting the `base` argument in `protocol._pack_s()` to a single byte is necessary to avoid a python exception.
2. Added handling for response `#` (unknown command) to `SerialConnection.recv()` since it can be sent by the CU, particularly when the firmware is missing.